### PR TITLE
add:複数安価時の文字列内安価の置換

### DIFF
--- a/handler/anka.go
+++ b/handler/anka.go
@@ -1,22 +1,18 @@
 package handler
 
 import (
-	"context"
 	"log"
 	"strconv"
 	"strings"
 
-	"github.com/google/uuid"
 	"github.com/traPtitech/traq-ws-bot/payload"
 )
 
 // 安価登録
 func (h *Handler) ankaProcessor(p *payload.MessageCreated) {
 	log.Println("Received MESSAGE_CREATED event: " + p.Message.Text)
-	h.ankaManager.AnkaReader(p.Message.Text)
-	channel, _, _ := h.bot.API().ChannelApi.GetChannel(context.Background(), p.Message.ChannelID).Execute()
 
-	posttext, isAnkaInvoke := h.ankaManager.ankaChecker(p.Message.ChannelID, p.Message.ID)
+	posttext, isAnkaInvoke := h.ankaManager.ankaChecker(p.Message.ChannelID, p.Message.ID, p.Message.Text, h)
 	if isAnkaInvoke {
 		h.BotSimplePost(p.Message.ChannelID, posttext)
 		h.BotSimplePost("baaf247d-125a-47e4-82a8-ffcccab5f0b8", posttext)
@@ -24,65 +20,58 @@ func (h *Handler) ankaProcessor(p *payload.MessageCreated) {
 	sep := strings.Fields(p.Message.Text)
 
 	if len(sep) == 2 {
-		if sep[0] != "@BOT_anka" {
-			return
+		if sep[0] == "@BOT_anka" {
+
+			if sep[1] == "join" {
+				log.Println("Received join command")
+				h.BotJoiner(p.Message.ChannelID)
+				return
+			}
+			if sep[1] == "leave" {
+				log.Println("Received leave command")
+				h.BotLeaver(p.Message.ChannelID)
+				return
+			}
 		}
-		if sep[1] == "join" {
-			log.Println("Received join command")
-			h.BotJoiner(p.Message.ChannelID)
-		}
-		if sep[1] == "leave" {
-			log.Println("Received leave command")
-			h.BotLeaver(p.Message.ChannelID)
-		}
 	}
 
-	ankames := []rune(sep[len(sep)-1])
+	viewMessage := h.ankaManager.AnkaReader(p)
 
-	if ankames[0] != '↓' {
-		log.Println(ankames[0])
-		return
+	posttext, isMessageCreate := viewMessage.ViewMessageMaker()
+	if isMessageCreate {
+		viewMessage.id = h.BotSimplePost(p.Message.ChannelID, posttext)
 	}
-	amount := string([]rune(ankames)[1:])
-	num, err := strconv.Atoi(amount)
-	if err != nil {
-		log.Println("Failed to parse")
-		return
-	}
-
-	if num < 1 {
-		log.Println("Invalid number")
-		return
-	}
-
-	ankaID := uuid.New().String()
-	newanka := &Anka{
-		id:           ankaID,
-		messageID:    p.Message.ID,
-		channelID:    p.Message.ChannelID,
-		messageCount: num,
-	}
-	h.ankaManager.AddAnka(*newanka)
-
-	log.Println("Add Ancor:" + "after" + strconv.Itoa(num) + ",in:" + channel.Name)
 
 }
 
 // 発火すべき安価があるか確認する
-func (am *AnkaManager) ankaChecker(channelid string, messageId string) (string, bool) {
+func (am *AnkaManager) ankaChecker(channelid string, messageId string, messageText string, h *Handler) (string, bool) {
 	ankas := am.DecrementAnkaMessageCount(channelid)
 	var ankaids []string
 	if !(len(ankas) > 0) {
 		return "", false
 	}
 	posttext := ""
+	ancorUrl := "https://q.trap.jp/messages/" + messageId
 	for _, anka := range ankas {
 		originUrl := "https://q.trap.jp/messages/" + anka.messageID
 		posttext += originUrl + "\n"
 		log.Println("Anka/in:", channelid)
 		ankaids = append(ankaids, anka.id)
+		replaceText := "[(↓" + strconv.Itoa(anka.originmessageCount) + ")" + messageText + "](" + ancorUrl + ")"
+		if anka.viewMessage == nil {
+			log.Println("viewMessageisNil (Maybe because of reset of Application)")
+			continue
+		}
+		anka.viewMessage.openedText[anka.inMessageAnkaOrder] = replaceText
+		updateAnkaViewText, isUpdate := anka.viewMessage.ViewMessageMaker()
+		if !isUpdate {
+			continue
+		}
+		h.BotSimpleUpdate(anka.viewMessage.id, updateAnkaViewText)
+
 	}
-	ancorUrl := "https://q.trap.jp/messages/" + messageId
+
 	for _, ankaid := range ankaids {
 		am.RemoveAnkaByID(ankaid)
 		log.Println("Remove Anka:" + ankaid + ",in:" + channelid)

--- a/handler/ankaTextReader.go
+++ b/handler/ankaTextReader.go
@@ -5,32 +5,68 @@ import (
 	"log"
 	"strconv"
 	"unicode"
+
+	"github.com/google/uuid"
+	"github.com/traPtitech/traq-ws-bot/payload"
 )
 
-func (am *AnkaManager) AnkaReader(message string) {
+func (am *AnkaManager) AnkaReader(p *payload.MessageCreated) *AnkaViewMessage {
 	log.Printf(":::AnkaReader Start:::")
-	messageRune := []rune(message)
+	nums := []int{}
+	ankaViewMessage := &AnkaViewMessage{}
+	ankaViewMessage.originText = make([]string, 0)
+	ankaViewMessage.openedText = make([]string, 0)
+	messageRune := []rune(p.Message.Text)
 
+	lastAnkaRuneNum := 0
 	for i := 0; i < len(messageRune); i++ {
 		fmt.Printf("%c", messageRune[i])
 		if messageRune[i] == '↓' {
 			log.Printf("::Anka Start::")
-			num := am.ankaNumReader(messageRune[i+1:])
+			num, length := am.ankaNumReader(messageRune[i+1:])
+			newAnka := &Anka{
+				id:                 uuid.New().String(),
+				messageID:          p.Message.ID,
+				channelID:          p.Message.ChannelID,
+				messageCount:       num,
+				originmessageCount: num,
+				inMessageAnkaOrder: len(nums),
+				viewMessage:        ankaViewMessage}
+			am.AddAnka(*newAnka)
+			nums = append(nums, num)
+			ankaViewMessage.originText = append(ankaViewMessage.originText, string(messageRune[lastAnkaRuneNum:i]))
+			ankaViewMessage.openedText = append(ankaViewMessage.openedText, string(messageRune[i:i+length+1]))
+			lastAnkaRuneNum = i + length + 1
 			log.Printf("::Anka detected:: %d", num)
 		}
 	}
+	ankaViewMessage.originText = append(ankaViewMessage.originText, string(messageRune[lastAnkaRuneNum:]))
 	fmt.Printf("\n")
 
+	// origintextの中身をforを使ってログ表示
+	for i, text := range ankaViewMessage.originText {
+		log.Printf("OriginText[%d]: %s", i, text)
+	}
+
+	// openedtextの中身をforを使ってログ表示
+	for i, text := range ankaViewMessage.openedText {
+		log.Printf("OpenedText[%d]: %s", i, text)
+	}
+
 	log.Printf(":::AnkaReader End:::")
+	return ankaViewMessage
+
 }
 
-func (am *AnkaManager) ankaNumReader(ankaOrigin []rune) int {
+func (am *AnkaManager) ankaNumReader(ankaOrigin []rune) (num int, length int) {
 	result := "0"
+	length = 0
 	log.Printf("::Anka Read Start::")
-	for i := 0; i < 12; i++ {
+	for i := 0; i < min(12, len(ankaOrigin)); i++ {
 		if !unicode.IsDigit(ankaOrigin[i]) {
 			break
 		}
+		length++
 		fmt.Printf("%c", ankaOrigin[i])
 		result += string(ankaOrigin[i])
 	}
@@ -41,5 +77,19 @@ func (am *AnkaManager) ankaNumReader(ankaOrigin []rune) int {
 	if err != nil {
 		log.Printf("AnkaNumReadError")
 	}
-	return num
+	return num, length
+}
+
+// 複数安価メッセージの編集用文の作成
+// bool→編集対象か(安価数が3以上か)
+func (vm *AnkaViewMessage) ViewMessageMaker() (string, bool) {
+	var result string
+	if len(vm.openedText) < 3 {
+		return "", false
+	}
+	for i, text := range vm.openedText {
+		result += vm.originText[i] + text
+	}
+	result += vm.originText[len(vm.originText)-1]
+	return result, true
 }

--- a/handler/botapi.go
+++ b/handler/botapi.go
@@ -25,6 +25,19 @@ func (h *Handler) BotSimplePost(channelID string, content string) (messageid str
 	return q.Id
 }
 
+func (h *Handler) BotSimpleUpdate(messageid string, content string) {
+	r, err := h.bot.API().
+		MessageApi.
+		EditMessage(context.Background(), messageid).PostMessageRequest(traq.PostMessageRequest{
+		Content: content,
+	}).Execute()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+	}
+
+}
+
 func (h *Handler) BotJoiner(channelID string) {
 	_, err := h.bot.API().BotApi.LetBotJoinChannel(context.Background(), os.Getenv("TRAQ_BOT_ID")).
 		PostBotActionJoinRequest(*traq.NewPostBotActionJoinRequest(channelID)).Execute()

--- a/handler/model.go
+++ b/handler/model.go
@@ -17,8 +17,17 @@ type AnkaManager struct {
 }
 
 type Anka struct {
-	id           string
-	messageID    string
-	channelID    string
-	messageCount int
+	id                 string
+	messageID          string
+	channelID          string
+	messageCount       int
+	originmessageCount int
+	inMessageAnkaOrder int
+	viewMessage        *AnkaViewMessage
+}
+
+type AnkaViewMessage struct {
+	id         string
+	originText []string
+	openedText []string
 }

--- a/handler/setup.go
+++ b/handler/setup.go
@@ -14,7 +14,6 @@ func NewHandler(bot *traqwsbot.Bot) *Handler {
 	newDB.Setup()
 	manager := &AnkaManager{ankas: make([]Anka, 0), db: newDB}
 	manager.ManagerSetupFromDB()
-	manager.AnkaReader("テストメッセージをここ↓123↓24に入力")
 	return &Handler{bot: bot, ankaManager: manager}
 }
 


### PR DESCRIPTION
## BOT_anka アップデートのお知らせ(第2弾)

### 更新内容
- 文字列内安価への対応
    - これまで末尾の矢印にしか反応しなかった安価が文の途中でも検知するようになりました
    - `安価↓23そろそろお寿司欲しい`みたいなことが可能になります

- 同一投稿内複数安価に対応
    - 一つの投稿の中に複数の安価を設置できるようになりました
    - 今のところ最大個数は設けていません

- 3つ以上の同一投稿内安価について、安価内容を反映したテキストを表示する機能を追加
    - 先の複数安価対応に伴って、安価内容をリアルタイムで反映する投稿を追加しました(参照が大変なため)
    - どんなものかは触ってみたらわかると思います 是非3安価以上の投稿を試してみてください
    - (こちらはDB永続化に対応していないためアプリが落ちると更新も止まります ご了承ください)

範囲指定ランダム安価は...ごめんなさい